### PR TITLE
Remove PatientObjectId

### DIFF
--- a/tconnectsync/api/android.py
+++ b/tconnectsync/api/android.py
@@ -69,7 +69,6 @@ class AndroidApi:
         self.refreshToken = j["refreshToken"]
         self.refreshTokenExpiresAt = j["refreshTokenExpiresAt"]
         self.userId = j["user"]["id"]
-        self.patientObjectId = j["user"]["patientObjectId"]
 
         logger.info("Logged in to AndroidApi successfully (expiration: %s, %s)" % (self.accessTokenExpiresAt, timeago(self.accessTokenExpiresAt)))
 


### PR DESCRIPTION
After trying to run auto update, I was met with an error saying that patientObjectId was not found, I commented the code out and the auto update ran. I propose that this line is removed as I do not see any use for the variable anywhere.