### PR TITLE
fix unknown therapy event error in ciq_therapy_event.py

### DIFF
--- a/tconnectsync/domain/therapy_event.py
+++ b/tconnectsync/domain/therapy_event.py
@@ -51,10 +51,50 @@ class CGMTherapyEvent(TherapyEvent):
     },
     """
     @classmethod
-    def parse(self, json):
+    def parse(_, json):
+        self = CGMTherapyEvent()
         TherapyEvent.parse(self, json)
         self.eventID = json['eventID']
         self.egv = json['egv']['estimatedGlucoseValue']
+        return self
+
+class BGTherapyEvent(TherapyEvent):
+    eventID = None
+    egv = None
+    """
+    {   
+        'bg': 160, # note in EGV
+        'cgmCalibration': 1, # not in EGV
+        'description': 'BG',
+        'deviceType': 't:slim X2 Insulin Pump',
+        'eventDateTime': '2022-08-20T07:25:24',
+        'eventTypeId': 16,
+        'indexId': 844955,
+        'interactive': 0,
+        'iob': 0.75,
+        'note': {   'active': False,
+                'eventId': 0, # different location than EGV
+                'eventTypeId': 16,
+                'id': 0,
+                'indexId': '',
+                'sourceRecordId': 0},
+        'requestDateTime': '0001-01-01T00:00:00',
+        'serialNumber': 'xxx',
+        'sourceRecId': 793549667,
+        'tempRateActivated': 0,
+        'tempRateCompleted': 0,
+        'tempRateId': 0,
+        'type': 'BG',
+        'uploadId': 748700213}
+    """    
+    @classmethod
+    def parse(_, json):
+        self = BGTherapyEvent()
+        TherapyEvent.parse(self, json)
+        self.eventID = json['note']['eventId']
+        # This is probably not how we want to provide CGM calibrations to Nightscout,
+        # but will just include it as egv data for now to keep the thing from crashing :)
+        self.egv = json['bg']
         return self
 
 class BolusTherapyEvent(TherapyEvent):
@@ -364,4 +404,28 @@ class BolusTherapyEvent(TherapyEvent):
         "tempRateCompleted": 0,
         "tempRateActivated": 0
     }
+    CGM Calibration (Therapy Event Type BG):
+    {   'bg': 160,
+        'cgmCalibration': 1,
+        'description': 'BG',
+        'deviceType': 't:slim X2 Insulin Pump',
+        'eventDateTime': '2022-08-20T07:25:24',
+        'eventTypeId': 16,
+        'indexId': 844955,
+        'interactive': 0,
+        'iob': 0.75,
+        'note': {   'active': False,
+                    'eventId': 0,
+                    'eventTypeId': 16,
+                    'id': 0,
+                    'indexId': '',
+                    'sourceRecordId': 0},
+        'requestDateTime': '0001-01-01T00:00:00',
+        'serialNumber': 'xxx',
+        'sourceRecId': 793549667,
+        'tempRateActivated': 0,
+        'tempRateCompleted': 0,
+        'tempRateId': 0,
+        'type': 'BG',
+        'uploadId': 0}
     """

--- a/tconnectsync/parser/ciq_therapy_events.py
+++ b/tconnectsync/parser/ciq_therapy_events.py
@@ -1,4 +1,4 @@
-from tconnectsync.domain.therapy_event import BolusTherapyEvent, CGMTherapyEvent
+from tconnectsync.domain.therapy_event import BolusTherapyEvent, CGMTherapyEvent, BGTherapyEvent
 from tconnectsync.parser.tconnect import TConnectEntry
 
 import logging
@@ -8,12 +8,16 @@ logger = logging.getLogger(__name__)
 def split_therapy_events(ciqTherapyEvents):
     bolusEvents = []
     cgmEvents = []
+    bgEvents = []
     for e in ciqTherapyEvents['event']:
         event = TConnectEntry.parse_therapy_event(e)
-        if type(event) == BolusTherapyEvent:
+        if isinstance(event, BolusTherapyEvent):
             bolusEvents.append(event)
-        elif type(event) == CGMTherapyEvent:
+        elif isinstance(event, CGMTherapyEvent): 
             cgmEvents.append(event)
+        elif isinstance(event, BGTherapyEvent):
+            bgEvents.append(event)
         
-    logger.debug("split_therapy_events: %d bolus, %d CGM" % (len(bolusEvents), len(cgmEvents)))
+    logger.debug("split_therapy_events: %d bolus, %d CGM, %d BG" % (len(bolusEvents), len(cgmEvents), len(bgEvents)))
+    # TODO: BG events (CGM Calibration) values are not currently returned from ciq_therapy_events.py
     return bolusEvents, cgmEvents

--- a/tconnectsync/parser/tconnect.py
+++ b/tconnectsync/parser/tconnect.py
@@ -3,7 +3,7 @@ import sys
 import arrow
 from tconnectsync.domain.bolus import Bolus
 
-from tconnectsync.domain.therapy_event import BolusTherapyEvent, CGMTherapyEvent
+from tconnectsync.domain.therapy_event import BolusTherapyEvent, CGMTherapyEvent, BGTherapyEvent
 
 try:
     from ..secret import TIMEZONE_NAME
@@ -200,6 +200,8 @@ class TConnectEntry:
             return BolusTherapyEvent.parse(data)
         elif data["type"] == "CGM":
             return CGMTherapyEvent.parse(data)
+        elif data["type"] == "BG":
+            return BGTherapyEvent.parse(data)
         
         raise UnknownTherapyEventException(data)
 


### PR DESCRIPTION
Lets try again 🤣 ... Addressing Issue #52 ... Fixing issue with unknown "BG" therapy events.

Added a BGTherapyEvent and handled it similar to the way Bolus and CGM TherapyEvent are handled after noticing that I had "BG" type data in my tconnect events.

A few more notes.... I noticed that the objects BolusTherapyEvent was created differently than CGMTherapyEvent and the new BGTherapyEvent which made checking their class/type uniformly challenging. Went and made sure their parse methods were updated similarly, and went ahead and changed the check for equivalence from type() to isinstance since I was there.