### PR TITLE
Fix format string in UnknownTherapyEventType.

### DIFF
--- a/tconnectsync/parser/tconnect.py
+++ b/tconnectsync/parser/tconnect.py
@@ -215,4 +215,5 @@ class UnknownBasalSuspensionEventException(Exception):
 
 class UnknownTherapyEventException(Exception):
     def __init__(self, data):
-        super().__init__("Unknown therapy event type: " % data)
+        typ = data["type"]
+        super().__init__(f"Unknown therapy event type: {typ} in {data}")


### PR DESCRIPTION
%s was missing from the format string. This enhances the message to report the unexpected therapy type along with the dump of the event that trigger the exception.