### PR TITLE
Moved remaining logger.warn() statements to logger.warning() 

### DIFF
--- a/tconnectsync/api/controliq.py
+++ b/tconnectsync/api/controliq.py
@@ -55,10 +55,10 @@ class ControlIQApi:
             self.tconnect_software_ver = version
             logger.info("Reported tconnect software version: %s" % version)
             if version != self.LAST_CONFIRMED_SOFTWARE_VERSION:
-                logger.warn("Newer API version than last confirmed working. Saw %s and expected %s" % (version, self.LAST_CONFIRMED_SOFTWARE_VERSION))
-                logger.warn("If you experience any issues, please report them to https://github.com/jwoglom/tconnectsync")
+                logger.warning("Newer API version than last confirmed working. Saw %s and expected %s" % (version, self.LAST_CONFIRMED_SOFTWARE_VERSION))
+                logger.warning("If you experience any issues, please report them to https://github.com/jwoglom/tconnectsync")
         except Exception:
-            logger.warn("Unable to find tconnect software version")
+            logger.warning("Unable to find tconnect software version")
             pass
         return {
             "__LASTFOCUS": "",

--- a/tconnectsync/autoupdate.py
+++ b/tconnectsync/autoupdate.py
@@ -76,7 +76,7 @@ class Autoupdate:
                                     logger.error("Exiting with error code due to AUTOUPDATE_RESTART_ON_FAILURE")
                                     return 1
                             else:
-                                logger.warn(AutoupdateFailureWarning(("%s: An event index change was recorded, but no new data was found via the API. " % datetime.datetime.now()) +
+                                logger.warning(AutoupdateFailureWarning(("%s: An event index change was recorded, but no new data was found via the API. " % datetime.datetime.now()) +
                                             "The %s was %d minutes ago. Resetting TConnectApi to attempt to solve this problem." % 
                                             ("last processed event" if self.last_successful_process_time_range else "start of autoupdate", (now - last_action_or_start)//60)))
                                 
@@ -143,7 +143,7 @@ class Autoupdate:
                 # uploaded, so 
                 if len(self.time_diffs_between_attempts) >= 3:
                     # The pump hasn't sent us data that, based on previous cadence, we were expecting
-                    logger.warn(AutoupdateNoIndexChangeWarning("Sleeping %d seconds after unexpected no index change based on previous cadence. (New data might be delayed.)" % 
+                    logger.warning(AutoupdateNoIndexChangeWarning("Sleeping %d seconds after unexpected no index change based on previous cadence. (New data might be delayed.)" % 
                         int(self.secret.AUTOUPDATE_UNEXPECTED_NO_INDEX_SLEEP_SECONDS)))
                     
                     logger.debug("Last event time: %s, time diffs between attempts: %s" % (self.last_event_time, self.time_diffs_between_attempts))

--- a/tconnectsync/process.py
+++ b/tconnectsync/process.py
@@ -86,19 +86,19 @@ def process_time_range(tconnect, nightscout, time_start, time_end, pretend, feat
        ciqFallingBack or \
        BOLUS_BG in features or \
        IOB in features:
-        logger.warn("Downloading t:connect CSV data")
+        logger.warning("Downloading t:connect CSV data")
         if bolusFallingBack:
-            logger.warn("Falling back on WS2 CSV data source because BOLUS is an enabled feature and CIQ bolus data was empty!!")
+            logger.warning("Falling back on WS2 CSV data source because BOLUS is an enabled feature and CIQ bolus data was empty!!")
         if ciqFallingBack:
-            logger.warn("Falling back on WS2 CSV data source because CGM is an enabled feature and CIQ cgm data was empty!!")
+            logger.warning("Falling back on WS2 CSV data source because CGM is an enabled feature and CIQ cgm data was empty!!")
         if BOLUS_BG in features:
-            logger.warn("Falling back on WS2 CSV data source because BOLUS_BG is an enabled feature. " +
+            logger.warning("Falling back on WS2 CSV data source because BOLUS_BG is an enabled feature. " +
                         "Please consider disabling this feature to improve synchronization reliability.")
         if IOB in features:
-            logger.warn("Falling back on WS2 CSV data source because IOB is an enabled feature. " +
+            logger.warning("Falling back on WS2 CSV data source because IOB is an enabled feature. " +
                         "Please consider disabling this feature to improve synchronization reliability.")
         
-        logger.warn("<!!> The WS2 data source is unreliable and may prevent timely synchronization")
+        logger.warning("<!!> The WS2 data source is unreliable and may prevent timely synchronization")
         csvdata = tconnect.ws2.therapy_timeline_csv(time_start, time_end)
 
         csvReadingData = csvdata["readingData"]
@@ -147,8 +147,8 @@ def process_time_range(tconnect, nightscout, time_start, time_end, pretend, feat
         pumpEvents = process_ciq_activity_events(ciqTherapyTimelineData)
         logger.debug("CIQ activity events: %s" % pumpEvents)
 
-        logger.warn("Using WS2 data source for basalsuspension because PUMP_EVENTS is an enabled feature")
-        logger.warn("<!!> The WS2 data source is unreliable and may prevent timely synchronization")
+        logger.warning("Using WS2 data source for basalsuspension because PUMP_EVENTS is an enabled feature")
+        logger.warning("<!!> The WS2 data source is unreliable and may prevent timely synchronization")
         ws2BasalSuspension = tconnect.ws2.basalsuspension(time_start, time_end)
 
         bsPumpEvents = process_basalsuspension_events(ws2BasalSuspension)
@@ -167,7 +167,7 @@ def process_time_range(tconnect, nightscout, time_start, time_end, pretend, feat
             bolusEvents = process_bolus_events(ciqBolusData, source="ciq")
 
         if csvBolusData and not bolusEvents:
-            logger.warn("Falling back on non-CIQ csvBolusData")
+            logger.warning("Falling back on non-CIQ csvBolusData")
             bolusEvents = process_bolus_events(csvBolusData, source="csv")
             logger.debug("ciq bolusEvents: %s" % bolusEvents)
         

--- a/tests/test_autoupdate.py
+++ b/tests/test_autoupdate.py
@@ -24,9 +24,9 @@ def build_mock_logger():
         logger.error(*args, **kwargs)
     
     def fake_warn(*args, **kwargs):
-        logger.warn(*args, **kwargs)
+        logger.warning(*args, **kwargs)
         
-    with patch("tconnectsync.autoupdate.logger.error") as mock_error, patch("tconnectsync.autoupdate.logger.warn") as mock_warn:
+    with patch("tconnectsync.autoupdate.logger.error") as mock_error, patch("tconnectsync.autoupdate.logger.warning") as mock_warn:
         mock_error.side_effect = fake_error
         mock_warn.side_effect = fake_warn
         yield (mock_error, mock_warn)


### PR DESCRIPTION
I was running the tests and ran into a series of deprecation messages on logger "warn()" being deprecated to "warning()". Did some searching, it looked like this has been standard for some time, so I went ahead and changed the function names to warning. No more deprecation messages 😄 