### PR TITLE
warn: log warning if configured pump has no recent data (stale serial)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ build
 .env
 tconnectsync-check-output.log
 ignore_*
+.venv/
+.vscode/

--- a/tconnectsync/__main__.py
+++ b/tconnectsync/__main__.py
@@ -1,0 +1,4 @@
+from . import main
+
+if __name__ == "__main__":
+    main()

--- a/tconnectsync/sync/tandemsource/choose_device.py
+++ b/tconnectsync/sync/tandemsource/choose_device.py
@@ -24,6 +24,20 @@ class ChooseDevice:
 
             tconnectDevice = serialNumberToPump[str(self.secret.PUMP_SERIAL_NUMBER)]
 
+            # Warn if pump is stale (no events in >3 days)
+            try:
+                max_event_date = arrow.get(tconnectDevice["maxDateWithEvents"])
+                age_days = (arrow.utcnow() - max_event_date).days
+
+                if age_days > 3:
+                    logger.warning(
+                        f"The selected pump (serial {tconnectDevice['serialNumber']}) has no events in the last {age_days} days "
+                        f"(last seen: {tconnectDevice['maxDateWithEvents']}). "
+                        "You may have switched to a new pump. Consider removing or updating PUMP_SERIAL_NUMBER in your config."
+                    )
+            except Exception as e:
+                logger.debug(f"Could not parse maxDateWithEvents to check for staleness: {e}")
+
             logger.info(f'Using pump with serial: {tconnectDevice["serialNumber"]} (tconnectDeviceId: {tconnectDevice["tconnectDeviceId"]}, last seen: {tconnectDevice["maxDateWithEvents"]})')
         else:
             maxDateSeen = None


### PR DESCRIPTION
## What this fixes:
When users switch to a new pump but don't update their `PUMP_SERIAL_NUMBER` env var, they may encounter confusing errors or silent failures. This PR adds a warning log when the configured pump serial number exists but has no events in the past 3 days.

## Why this matters:
This helps users self-diagnose a common issue after hardware changes, like upgrading to the Tandem Mobi, without breaking existing behavior or forcing fallback logic.


## Included changes:
Functional Changes:
1. Warn when selected pump has no recent data (choose_device.py)

Non-functional Changes:
1. Updated .gitignore to exclude local .venv/ and .vscode/ dirs (for cleaner development)
2. (Optional) Added __main__.py to support `python -m tconnectsync` for debugging and development.


## How to test:
1. Set `PUMP_SERIAL_NUMBER` to a known stale serial.
2. Run `python -m tconnectsync --check-login` or hit the /check_login in the app

Observe warning in logs:
```
WARNING: The selected pump (serial 12345678) has no events in the last 10 days (last seen: ...)
```

Let me know if you'd prefer to exclude the __main__.py file, happy to drop that commit.



## Note:
While syncing insulin data works correctly after updating or removing the stale PUMP_SERIAL_NUMBER, the `/check_login` endpoint still fails due to an upstream issue with the ControlIQ login scraping logic (`soup.select_one("#__VIEWSTATE")` returns `None`).

This appears to be unrelated to our patch and likely reflects a structural change in the t:connect web portal.

Suggestion: Consider wrapping the soup.select_one(...)["value"] logic in a try/except block and logging the raw HTML content or URL returned. This would help diagnose the root cause when the HTML format changes unexpectedly.

Example error:
```
Traceback (most recent call last):
  File "/app/.heroku/python/lib/python3.9/site-packages/tconnectsync/check.py", line 85, in check_login
    summary = tconnect.controliq.dashboard_summary(time_start, time_end)
  File "/app/.heroku/python/lib/python3.9/site-packages/tconnectsync/api/__init__.py", line 43, in controliq
    self._ciq = ControlIQApi(self.email, self.password)
  File "/app/.heroku/python/lib/python3.9/site-packages/tconnectsync/api/controliq.py", line 25, in __init__
    self.login(email, password)
  File "/app/.heroku/python/lib/python3.9/site-packages/tconnectsync/api/controliq.py", line 34, in login
    data = self._build_login_data(email, password, soup)
  File "/app/.heroku/python/lib/python3.9/site-packages/tconnectsync/api/controliq.py", line 100, in _build_login_data
    "__VIEWSTATE": soup.select_one("#__VIEWSTATE")["value"],
TypeError: 'NoneType' object is not subscriptable
```