### PR TITLE
Fix auto-update only running for 24 hours

### DIFF
--- a/tconnectsync/__init__.py
+++ b/tconnectsync/__init__.py
@@ -117,7 +117,7 @@ def main(*args, **kwargs):
 
     if args.auto_update:
         u = TandemSourceAutoupdate(secret)
-        sys.exit(u.process(tconnect, nightscout, time_start, time_end, args.pretend, features=args.features))
+        sys.exit(u.process(tconnect, nightscout, args.pretend, features=args.features))
     else:
         tconnectDevice = TandemSourceChooseDevice(secret, tconnect).choose()
         added, last_event_id = TandemSourceProcessTimeRange(tconnect, nightscout, tconnectDevice, pretend=args.pretend, secret=secret, features=args.features).process(time_start, time_end)

--- a/tconnectsync/sync/tandemsource/autoupdate.py
+++ b/tconnectsync/sync/tandemsource/autoupdate.py
@@ -27,7 +27,7 @@ class TandemSourceAutoupdate:
     until stopped (ctrl+c), or a maximum of AUTOUPDATE_MAX_LOOP_INVOCATIONS times.
     Stops if AUTOUPDATE_RESTART_ON_FAILURE is set and an error occurs.
     """
-    def process(self, tconnect, nightscout, time_start, time_end, pretend, features=None):
+    def process(self, tconnect, nightscout, pretend, features=None):
         if features is None:
             features = DEFAULT_FEATURES
 
@@ -50,7 +50,7 @@ class TandemSourceAutoupdate:
                 if pretend:
                     logger.info('Would update now if not in pretend mode')
                 else:
-                    added, event_seqnum = ProcessTimeRange(tconnect, nightscout, tconnectDevice, pretend, self.secret, features=features).process(time_start, time_end)
+                    added, event_seqnum = ProcessTimeRange(tconnect, nightscout, tconnectDevice, pretend, self.secret, features=features).process(None, None)
                     logger.info('Added %d items from ProcessTimeRange' % added)
                     self.last_successful_process_time_range = now
 


### PR DESCRIPTION
The reason the auto-updater only works for 24 hours is because [time_start and time_end are set even when the auto-updater option is specified.](https://github.com/jwoglom/tconnectsync/blob/803b15b886b908a9acefed440ad57aa47f9ade94/tconnectsync/__init__.py#L82-L83) I don't think it makes sense for the auto-updater to support limiting itself to a time range, so I removed those variables and replace them with None so that it will always grab the current day.

This should fix #11.