### PR TITLE
I've made the following changes to address the date parsing and inval…

### DIFF
--- a/tconnectsync/eventparser/events.py
+++ b/tconnectsync/eventparser/events.py
@@ -2507,6 +2507,7 @@ class LidCgmAlertActivated(BaseEvent):
         CgmFailedConnection = 27
         CgmTransmitterExpired = 39
         PumpBluetoothError = 40
+        UnknownAlert2 = 2
 
     @property
     def dalertid(self):
@@ -2567,6 +2568,7 @@ class LidCgmAlertCleared(BaseEvent):
     dalertidRaw: int
 
     DalertidMap = {
+        "2": "Unknown Alert 2",
         "11": "CGM Sensor Fail",
         "13": "CGM Sensor Expired",
         "14": "CGM Out Of Range",
@@ -2586,6 +2588,7 @@ class LidCgmAlertCleared(BaseEvent):
         CgmFailedConnection = 27
         CgmTransmitterExpired = 39
         PumpBluetoothError = 40
+        UnknownAlert2 = 2
 
     @property
     def dalertid(self):
@@ -3998,6 +4001,7 @@ class LidCgmAlertActivatedDex(BaseEvent):
     param2: float
 
     DalertidMap = {
+        "2": "Unknown Alert 2",
         "11": "CGM Sensor Fail",
         "13": "CGM Sensor Expired",
         "14": "CGM Out Of Range",
@@ -4017,6 +4021,7 @@ class LidCgmAlertActivatedDex(BaseEvent):
         CgmFailedConnection = 27
         CgmTransmitterExpired = 39
         PumpBluetoothError = 40
+        UnknownAlert2 = 2
 
     @property
     def dalertid(self):
@@ -4101,6 +4106,7 @@ class LidCgmAlertClearedDex(BaseEvent):
     sensortypeRaw: int
 
     DalertidMap = {
+        "2": "Unknown Alert 2",
         "11": "CGM Sensor Fail",
         "13": "CGM Sensor Expired",
         "14": "CGM Out Of Range",
@@ -4120,6 +4126,7 @@ class LidCgmAlertClearedDex(BaseEvent):
         CgmFailedConnection = 27
         CgmTransmitterExpired = 39
         PumpBluetoothError = 40
+        UnknownAlert2 = 2
 
     @property
     def dalertid(self):

--- a/tconnectsync/nightscout.py
+++ b/tconnectsync/nightscout.py
@@ -4,6 +4,7 @@ import hashlib
 import time
 import urllib.parse
 import arrow
+import arrow.parser
 import logging
 
 from urllib.parse import urljoin
@@ -12,7 +13,20 @@ from .api.common import ApiException
 from .parser.nightscout import ENTERED_BY
 
 def format_datetime(date):
-	return arrow.get(date).isoformat()
+    try:
+        # Try parsing with 'T' separator and timezone
+        return arrow.get(date).isoformat()
+    except arrow.parser.ParserError:
+        try:
+            # Try parsing with space separator and timezone
+            return arrow.get(date.replace('T', ' '), 'YYYY-MM-DD HH:mm:ssZZ').isoformat()
+        except arrow.parser.ParserError:
+            try:
+                # Try parsing with 'T' separator without timezone
+                return arrow.get(date, 'YYYY-MM-DDTHH:mm:ss').isoformat()
+            except arrow.parser.ParserError:
+                # Try parsing with space separator without timezone
+                return arrow.get(date.replace('T', ' '), 'YYYY-MM-DD HH:mm:ss').isoformat()
 
 def time_range(field_name, start_time, end_time, t_to_space=False):
 	def fmt(date):

--- a/tconnectsync/sync/tandemsource/process_cgm_alert.py
+++ b/tconnectsync/sync/tandemsource/process_cgm_alert.py
@@ -79,6 +79,13 @@ class ProcessCGMAlert:
             if alert.dalertid == eventtypes.LidCgmAlertActivatedDex.DalertidEnum.CgmOutOfRange:
                 logger.info("ProcessCGMAlert: Skipping alert with CgmOutOfRange dalertid %d: %s" % (alert.dalertidRaw, alert))
                 return None
+            elif alert.dalertid == eventtypes.LidCgmAlertActivatedDex.DalertidEnum.UnknownAlert2:
+                logger.info("ProcessCGMAlert: Processing alert with UnknownAlert2 dalertid %d: %s" % (alert.dalertidRaw, alert))
+                return NightscoutEntry.cgm_alert(
+                    created_at = alert.eventTimestamp.format(),
+                    reason = "Dexcom CGM Alert (Unknown Alert 2)",
+                    pump_event_id = "%s" % alert.seqNum
+                )
             return NightscoutEntry.cgm_alert(
                 created_at = alert.eventTimestamp.format(),
                 reason = ("Dexcom CGM Alert (%s)" % alert.dalertid.name) if alert.dalertid else "Dexcom CGM Alert (Unknown)",

--- a/tests/eventparser/__init__.py
+++ b/tests/eventparser/__init__.py
@@ -1,0 +1,1 @@
+# This file makes Python treat the 'eventparser' directory as a package.

--- a/tests/eventparser/test_events.py
+++ b/tests/eventparser/test_events.py
@@ -1,0 +1,46 @@
+import unittest
+from tconnectsync.eventparser.events import LidCgmAlertActivatedDex, LidCgmAlertClearedDex
+from tconnectsync.eventparser.raw_event import RawEvent
+import arrow
+
+class TestEventParserEvents(unittest.TestCase):
+    def test_lid_cgm_alert_activated_dex_unknown_alert_2(self):
+        # Create a dummy RawEvent
+        raw_event_data = bytearray(b'\x01q \xc9!k\x00\x02\t\xc3\x00\x00\x02\x0e\x00\x00!\x0e\x00\x00\x00\x14D\\@\x00') # Example raw data, modify if needed
+
+        # Modify bytes for dalertidRaw = 2 and other relevant fields if necessary
+        # Assuming dalertid is at byte index 13 as per LidCgmAlertActivatedDex structure
+        # raw_event_data[13] = 2 # This is a simplified example, actual byte manipulation might be more complex
+
+        # For the purpose of this test, we will mock the build method to directly inject the dalertidRaw value
+        # as byte manipulation is complex and error-prone without deeper knowledge of the byte structure.
+
+        mock_raw_event = RawEvent(source=0, id=369, timestampRaw=0, seqNum=0, raw=bytearray(b''))
+
+        event = LidCgmAlertActivatedDex(
+            raw=mock_raw_event, # This would ideally be a properly constructed RawEvent
+            dalertidRaw=2,
+            sensortypeRaw=3, # Example value
+            faultlocatordata=0, # Example value
+            param1=0, # Example value
+            param2=0.0 # Example value
+        )
+        self.assertEqual(event.dalertidRaw, 2)
+        self.assertEqual(event.dalertid, LidCgmAlertActivatedDex.DalertidEnum.UnknownAlert2)
+        self.assertIn("Unknown Alert 2", LidCgmAlertActivatedDex.DalertidMap.get("2"))
+
+    def test_lid_cgm_alert_cleared_dex_unknown_alert_2(self):
+        mock_raw_event = RawEvent(source=0, id=370, timestampRaw=0, seqNum=0, raw=bytearray(b''))
+
+        event = LidCgmAlertClearedDex(
+            raw=mock_raw_event, # This would ideally be a properly constructed RawEvent
+            dalertidRaw=2,
+            sensortypeRaw=3 # Example value
+        )
+        self.assertEqual(event.dalertidRaw, 2)
+        self.assertEqual(event.dalertid, LidCgmAlertClearedDex.DalertidEnum.UnknownAlert2)
+        self.assertIn("Unknown Alert 2", LidCgmAlertClearedDex.DalertidMap.get("2"))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_nightscout_date_parsing.py
+++ b/tests/test_nightscout_date_parsing.py
@@ -1,0 +1,21 @@
+import unittest
+import arrow
+from tconnectsync.nightscout import format_datetime
+
+class TestNightscoutDateParsing(unittest.TestCase):
+    def test_format_datetime_various_formats(self):
+        # Test with 'T' separator and timezone
+        self.assertEqual(format_datetime("2023-10-26T10:00:00+02:00"), "2023-10-26T10:00:00+02:00")
+        # Test with space separator and timezone
+        self.assertEqual(format_datetime("2023-10-26 10:00:00+02:00"), "2023-10-26T10:00:00+02:00")
+        # Test with 'T' separator without timezone
+        self.assertEqual(format_datetime("2023-10-26T10:00:00"), "2023-10-26T10:00:00+00:00") # Arrow defaults to UTC
+        # Test with space separator without timezone
+        self.assertEqual(format_datetime("2023-10-26 10:00:00"), "2023-10-26T10:00:00+00:00") # Arrow defaults to UTC
+
+    def test_format_datetime_invalid_format(self):
+        with self.assertRaises(arrow.parser.ParserError):
+            format_datetime("invalid-date-format")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
…id `dalertidRaw` issues:

- I modified the `format_datetime` function in `tconnectsync/nightscout.py` to handle various ISO 8601 date formats, making date parsing more robust.
- I added the missing `dalertidRaw` value `2` (as `UnknownAlert2`) to `DalertidEnum` and `DalertidMap` for `LidCgmAlertActivatedDex` and `LidCgmAlertClearedDex` in `tconnectsync/eventparser/events.py`.
- I updated `tconnectsync/sync/tandemsource/process_cgm_alert.py` to handle the new `UnknownAlert2` by creating a generic alert message.
- I added unit tests for the date parsing and `dalertidRaw` changes. These new tests pass.