### PR TITLE
Add timezone support to CGM timestamp calculation

### DIFF
--- a/tconnectsync/sync/tandemsource/process_cgm_reading.py
+++ b/tconnectsync/sync/tandemsource/process_cgm_reading.py
@@ -3,6 +3,7 @@ import arrow
 
 from ...features import DEFAULT_FEATURES
 from ... import features
+from ...secret import TIMEZONE_NAME
 from ...eventparser.generic import Events, decode_raw_events, EVENT_LEN
 from ...eventparser.utils import bitmask_to_list
 from ...eventparser.raw_event import TANDEM_EPOCH
@@ -66,7 +67,7 @@ class ProcessCGMReading:
     def timestamp_for(self, event):
         # For backfills the time the event was added to the pump's event store
         # might not be the time it actually occurred, so we use the egvTimestamp
-        return arrow.get(TANDEM_EPOCH + event.egvTimestamp)
+        return arrow.get(TANDEM_EPOCH + event.egvTimestamp, tzinfo='UTC').replace(tzinfo=TIMEZONE_NAME)
 
     def to_nsentry(self, event):
         return NightscoutEntry.entry(


### PR DESCRIPTION
CGM data was being uploaded to Nightscout in the wrong timezone format. This resolved the issue and I've tested it with a few different instances to verify.