### PR TITLE
fix: upgrade Python 3.9 → 3.11 to fix missing python-dotenv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim as base
+FROM python:3.11-slim as base
 
 # The following is adapted from:
 # https://sourcery.ai/blog/python-docker/


### PR DESCRIPTION
fix missing python-dotenv