### PR TITLE
Fix LidDailyBasal battery parsing

### DIFF
--- a/tconnectsync/eventparser/custom_events.json
+++ b/tconnectsync/eventparser/custom_events.json
@@ -18,18 +18,18 @@
           "offset": 8,
           "uom": "units"
         },
-        "batteryChargePercentMSBRaw": {
-          "type": "uint8",
-          "offset": 12
-        },
-        "batteryChargePercentLSBRaw": {
-          "type": "uint8",
-          "offset": 13,
-          "transform": [["battery_charge_percent", ""]]
-        },
         "batteryLipoMilliVolts": {
           "type": "uint16",
+          "offset": 12
+        },
+        "batteryChargePercent": {
+          "type": "uint8",
           "offset": 14
+        },
+        "batteryStatusRaw": {
+          "type": "uint8",
+          "offset": 15,
+          "transform": [["battery_charge_percent", ""]]
         }
       }
     },

--- a/tconnectsync/eventparser/events.py
+++ b/tconnectsync/eventparser/events.py
@@ -5557,31 +5557,39 @@ class LidDailyBasal(BaseEvent):
     dailytotalbasal: float # units
     lastbasalrate: float # units/hour
     iob: float # units
-    batterychargepercentmsbRaw: int
-    batterychargepercentlsbRaw: int
     batterylipomillivolts: int
+    batterychargepercent: int
+    batterystatusRaw: int
 
     @property
     def batteryChargePercent(self):
-        return (256*(self.batterychargepercentmsbRaw-14)+self.batterychargepercentlsbRaw)/(3*256)
+        return self.batterychargepercent / 100
+
+    @property
+    def batterychargepercentmsbRaw(self):
+        return (self.batterylipomillivolts >> 8) & 0xff
+
+    @property
+    def batterychargepercentlsbRaw(self):
+        return self.batterylipomillivolts & 0xff
 
     @staticmethod
     def build(raw):
         dailytotalbasal, = struct.unpack_from(FLOAT32, raw[:EVENT_LEN], 10)
         lastbasalrate, = struct.unpack_from(FLOAT32, raw[:EVENT_LEN], 14)
         iob, = struct.unpack_from(FLOAT32, raw[:EVENT_LEN], 18)
-        batterychargepercentmsbRaw, = struct.unpack_from(UINT8, raw[:EVENT_LEN], 22)
-        batterychargepercentlsbRaw, = struct.unpack_from(UINT8, raw[:EVENT_LEN], 23)
-        batterylipomillivolts, = struct.unpack_from(UINT16, raw[:EVENT_LEN], 24)
+        batterylipomillivolts, = struct.unpack_from(UINT16, raw[:EVENT_LEN], 22)
+        batterychargepercent, = struct.unpack_from(UINT8, raw[:EVENT_LEN], 24)
+        batterystatusRaw, = struct.unpack_from(UINT8, raw[:EVENT_LEN], 25)
 
         return LidDailyBasal(
             raw = RawEvent.build(raw),
             dailytotalbasal = dailytotalbasal,
             lastbasalrate = lastbasalrate,
             iob = iob,
-            batterychargepercentmsbRaw = batterychargepercentmsbRaw,
-            batterychargepercentlsbRaw = batterychargepercentlsbRaw,
             batterylipomillivolts = batterylipomillivolts,
+            batterychargepercent = batterychargepercent,
+            batterystatusRaw = batterystatusRaw,
         )
 
     @property
@@ -5605,9 +5613,9 @@ class LidDailyBasal(BaseEvent):
             dailytotalbasal=self.dailytotalbasal,
             lastbasalrate=self.lastbasalrate,
             iob=self.iob,
-            batterychargepercentmsbRaw=self.batterychargepercentmsbRaw,
-            batterychargepercentlsbRaw=self.batterychargepercentlsbRaw,
             batterylipomillivolts=self.batterylipomillivolts,
+            batterychargepercent=self.batterychargepercent,
+            batterystatusRaw=self.batterystatusRaw,
         )
 
 

--- a/tconnectsync/eventparser/transforms.py
+++ b/tconnectsync/eventparser/transforms.py
@@ -142,7 +142,15 @@ def transform_battery_charge_percent(event_def, name, name_fmt, field, tx):
     out += [
         '@property',
         f'def batteryChargePercent(self):',
-        f'    return (256*(self.batterychargepercentmsbRaw-14)+self.batterychargepercentlsbRaw)/(3*256)',
+        f'    return self.batterychargepercent / 100',
+        '',
+        '@property',
+        f'def batterychargepercentmsbRaw(self):',
+        f'    return (self.batterylipomillivolts >> 8) & 0xff',
+        '',
+        '@property',
+        f'def batterychargepercentlsbRaw(self):',
+        f'    return self.batterylipomillivolts & 0xff',
         ''
     ]
 

--- a/tconnectsync/sync/tandemsource/process_device_status.py
+++ b/tconnectsync/sync/tandemsource/process_device_status.py
@@ -60,7 +60,7 @@ class ProcessDeviceStatus:
         return NightscoutEntry.devicestatus(
             created_at=event.eventTimestamp.format(),
             batteryVoltage=(float(event.batterylipomillivolts or 0)/1000),
-            batteryPercent=int(100*event.batteryChargePercent),
+            batteryPercent=event.batterychargepercent,
             pump_event_id = "%s" % event.seqNum
         )
 

--- a/tests/sync/tandemsource/test_process_device_status.py
+++ b/tests/sync/tandemsource/test_process_device_status.py
@@ -28,9 +28,9 @@ class TestProcessDeviceStatus(unittest.TestCase):
         ]
 
         self.assertEqual(type(events[0]), eventtypes.LidDailyBasal)
-        self.assertEqual(events[0].batterychargepercentmsbRaw, 14)
-        self.assertEqual(events[0].batterychargepercentlsbRaw, 246)
-        self.assertEqual(events[0].batterylipomillivolts, 14080)
+        self.assertEqual(events[0].batterylipomillivolts, 3830)
+        self.assertEqual(events[0].batterychargepercent, 55)
+        self.assertEqual(events[0].batterystatusRaw, 0)
 
         p = self.process.process(events, time_start=None, time_end=None)
 
@@ -41,9 +41,9 @@ class TestProcessDeviceStatus(unittest.TestCase):
             'pump': {
                 'clock': '2024-12-03 23:40:23-05:00',
                 'battery': {
-                    'status': '32%',
-                    'percent': 32,
-                    'voltage': 14.08
+                    'status': '55%',
+                    'percent': 55,
+                    'voltage': 3.83
                 }
             },
             'pump_event_id': '1046436'
@@ -57,9 +57,9 @@ class TestProcessDeviceStatus(unittest.TestCase):
         ]
 
         self.assertEqual(type(events[0]), eventtypes.LidDailyBasal)
-        self.assertEqual(events[0].batterychargepercentmsbRaw, 14)
-        self.assertEqual(events[0].batterychargepercentlsbRaw, 246)
-        self.assertEqual(events[0].batterylipomillivolts, 14080)
+        self.assertEqual(events[0].batterylipomillivolts, 3830)
+        self.assertEqual(events[0].batterychargepercent, 55)
+        self.assertEqual(events[0].batterystatusRaw, 0)
 
         p = self.process.process(events, time_start=None, time_end=None)
 
@@ -76,15 +76,15 @@ class TestProcessDeviceStatus(unittest.TestCase):
 
         self.assertEqual(type(events[0]), eventtypes.LidDailyBasal)
         self.assertEqual(events[0].raw.timestampRaw, 534123623) # 2024-12-03 23:40:23-05:00
-        self.assertEqual(events[0].batterychargepercentmsbRaw, 14)
-        self.assertEqual(events[0].batterychargepercentlsbRaw, 246)
-        self.assertEqual(events[0].batterylipomillivolts, 14080)
+        self.assertEqual(events[0].batterylipomillivolts, 3830)
+        self.assertEqual(events[0].batterychargepercent, 55)
+        self.assertEqual(events[0].batterystatusRaw, 0)
 
         self.assertEqual(type(events[1]), eventtypes.LidDailyBasal)
         self.assertEqual(events[1].raw.timestampRaw, 534133823) # 2024-12-04 02:30:23-05:00
-        self.assertEqual(events[1].batterychargepercentmsbRaw, 14)
-        self.assertEqual(events[1].batterychargepercentlsbRaw, 243)
-        self.assertEqual(events[1].batterylipomillivolts, 13824)
+        self.assertEqual(events[1].batterylipomillivolts, 3827)
+        self.assertEqual(events[1].batterychargepercent, 54)
+        self.assertEqual(events[1].batterystatusRaw, 0)
 
         p = self.process.process(events, time_start=None, time_end=None)
 
@@ -95,9 +95,9 @@ class TestProcessDeviceStatus(unittest.TestCase):
             'pump': {
                 'clock': '2024-12-04 02:30:23-05:00',
                 'battery': {
-                    'status': '31%',
-                    'percent': 31,
-                    'voltage': 13.824
+                    'status': '54%',
+                    'percent': 54,
+                    'voltage': 3.827
                 }
             },
             'pump_event_id': '1046875'
@@ -114,21 +114,21 @@ class TestProcessDeviceStatus(unittest.TestCase):
 
         self.assertEqual(type(events[0]), eventtypes.LidDailyBasal)
         self.assertEqual(events[0].raw.timestampRaw, 534123623) # 2024-12-03 23:40:23-05:00
-        self.assertEqual(events[0].batterychargepercentmsbRaw, 14)
-        self.assertEqual(events[0].batterychargepercentlsbRaw, 246)
-        self.assertEqual(events[0].batterylipomillivolts, 14080)
+        self.assertEqual(events[0].batterylipomillivolts, 3830)
+        self.assertEqual(events[0].batterychargepercent, 55)
+        self.assertEqual(events[0].batterystatusRaw, 0)
 
         self.assertEqual(type(events[1]), eventtypes.LidDailyBasal)
         self.assertEqual(events[1].raw.timestampRaw, 534133823) # 2024-12-04 02:30:23-05:00
-        self.assertEqual(events[1].batterychargepercentmsbRaw, 14)
-        self.assertEqual(events[1].batterychargepercentlsbRaw, 243)
-        self.assertEqual(events[1].batterylipomillivolts, 13824)
+        self.assertEqual(events[1].batterylipomillivolts, 3827)
+        self.assertEqual(events[1].batterychargepercent, 54)
+        self.assertEqual(events[1].batterystatusRaw, 0)
 
         self.assertEqual(type(events[2]), eventtypes.LidDailyBasal)
         self.assertEqual(events[2].raw.timestampRaw, 534145823) # 2024-12-04 05:50:23-05:00
-        self.assertEqual(events[2].batterychargepercentmsbRaw, 14)
-        self.assertEqual(events[2].batterychargepercentlsbRaw, 238)
-        self.assertEqual(events[2].batterylipomillivolts, 13568)
+        self.assertEqual(events[2].batterylipomillivolts, 3822)
+        self.assertEqual(events[2].batterychargepercent, 53)
+        self.assertEqual(events[2].batterystatusRaw, 0)
 
         p = self.process.process(events, time_start=None, time_end=None)
 
@@ -139,13 +139,32 @@ class TestProcessDeviceStatus(unittest.TestCase):
             'pump': {
                 'clock': '2024-12-04 05:50:23-05:00',
                 'battery': {
-                    'status': '30%',
-                    'percent': 30,
-                    'voltage': 13.568
+                    'status': '53%',
+                    'percent': 53,
+                    'voltage': 3.822
                 }
             },
             'pump_event_id': '1047614'
         })
+
+    def test_lid_daily_basal_battery_suffix_decoding(self):
+        base = bytearray(b'\x00Q\x1f\xd6\x14g\x00\x0f\xf7\xa4A\xb2\xd3\xe2?L\xcc\xcd@~\xdeb\x00\x00\x00\x00')
+
+        examples = [
+            (b'\x10\x6c\x64\x00', 4204, 100, 0),
+            (b'\x0f\xcb\x5b\x00', 4043, 91, 0),
+            (b'\x0f\xfb\x5a\x00', 4091, 90, 0),
+        ]
+
+        for suffix, voltage, percent, status in examples:
+            with self.subTest(suffix=suffix.hex(" ")):
+                raw = base[:]
+                raw[-4:] = suffix
+                event = Event(bytes(raw))
+                self.assertEqual(event.batterylipomillivolts, voltage)
+                self.assertEqual(event.batterychargepercent, percent)
+                self.assertEqual(event.batterystatusRaw, status)
+                self.assertEqual(event.batteryChargePercent, percent / 100)
 
     @unittest.skip
     def test_device_status_battery_calculation(self):


### PR DESCRIPTION
**What This Adds/Changes**

Fixes `LidDailyBasal` battery parsing so the final 4 bytes are decoded as:

```text
battery_lipo_millivolts: uint16
battery_charge_percent: uint8
battery_status_raw: uint8
```

Updates Nightscout devicestatus mapping to use the decoded battery percent directly, and refreshes device status tests to expect realistic voltage/percent values.

**Why Was Needed**

The previous parser treated the final bytes as battery percent MSB/LSB plus voltage, which produced incorrect values like `14.08V` and derived battery percentages.

Based on the message log data shared in [issue comment #110](https://github.com/jwoglom/tconnectsync/issues/110#issuecomment-2560443228), we can confirm the correct layout is voltage first, then percent, then status.

From the log data:

Currently parsed as:

- `batterychargepercentmsbRaw = 16`
- `batterychargepercentlsbRaw = 108`
- `batterylipomillivolts = 25600`

Correct decode:

- `battery_lipo_millivolts = 0x106c = 4204`
- `battery_charge_percent = 0x64 = 100`
- `battery_status_raw = 0x00`

More examples:

- `10 4e 63 00` => `4174 mV`, `99%`
- `10 45 62 00` => `4165 mV`, `98%`
- `10 34 61 00` => `4148 mV`, `97%`
- `0f cb 5b 00` => `4043 mV`, `91%`
- `0f fb 5a 00` => `4091 mV`, `90%`

This was also tested on my own setup using Nightscout and a Tandem t:slim pump.

**How It Works**

`LidDailyBasal.build()` now reads:

```python
batterylipomillivolts = uint16_be(raw[22:24])
batterychargepercent = raw[24]
batterystatusRaw = raw[25]
```

`batteryChargePercent` remains available as a compatibility property and returns the decimal form of the percent, e.g. `1.0` for `100%`.

Nightscout devicestatus now sends:

```python
batteryVoltage = batterylipomillivolts / 1000
batteryPercent = batterychargepercent
```

**Files Changed**

- `tconnectsync/eventparser/custom_events.json`
- `tconnectsync/eventparser/events.py`
- `tconnectsync/eventparser/transforms.py`
- `tconnectsync/sync/tandemsource/process_device_status.py`
- `tests/sync/tandemsource/test_process_device_status.py`

**Backward Compatibility**

Existing callers using `batteryChargePercent` still work.

The old raw attribute names are preserved as compatibility properties:

```python
batterychargepercentmsbRaw
batterychargepercentlsbRaw
```

They now reflect the high/low bytes of the decoded battery voltage instead of representing the old incorrect percent calculation.

 **Tested with real data**
- Before (wrong battery data):
<img width="2309" height="1285" alt="Wrong Battery Info" src="https://github.com/user-attachments/assets/9cd41eef-e82a-4469-b4fa-7894c96fd5e1" />

- After  (good battery data):
<img width="2309" height="1285" alt="Fixed Battery  info" src="https://github.com/user-attachments/assets/2bfb19f9-cf5f-4087-95af-f3be7b6cdea4" />
